### PR TITLE
feat: 공통 에러 처리 작성

### DIFF
--- a/src/main/java/com/album2me/repost/domain/user/dto/request/UserCreateRequest.java
+++ b/src/main/java/com/album2me/repost/domain/user/dto/request/UserCreateRequest.java
@@ -2,19 +2,15 @@ package com.album2me.repost.domain.user.dto.request;
 
 import com.album2me.repost.domain.user.model.User;
 import com.album2me.repost.global.util.RegexUtils;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 public record UserCreateRequest(
-        @NotBlank(message = "아이디는 필수입니다.")
         @Pattern(regexp = RegexUtils.AUTHID_REGEX, message = "아이디는 한글, 숫자, 영어로 된 4~20자입니다.")
         String authId,
-        @NotBlank(message = "비밀번호는 필수입니다..")
         @Pattern(regexp = RegexUtils.PASSWORD_REGEX, message = "비밀번호는 숫자, 영어, 특수문자를 1개 이상 포함한 8~20자입니다.")
         String password,
-        @NotBlank(message = "닉네임은 필수입니다.")
-        @Pattern(regexp = RegexUtils.NICKNAME_REGEX, message = "아이디는 한글, 숫자, 영어로 된 2~10자입니다.")
+        @Pattern(regexp = RegexUtils.NICKNAME_REGEX, message = "닉네임은 한글, 숫자, 영어로 된 2~10자입니다.")
         String nickname
 ){
 

--- a/src/main/java/com/album2me/repost/global/error/ErrorCode.java
+++ b/src/main/java/com/album2me/repost/global/error/ErrorCode.java
@@ -1,0 +1,20 @@
+package com.album2me.repost.global.error;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+
+    //COMMON
+    INVALID_ARGUMENT(400, 1000, "유효하지 않은 입력.");
+
+    private final int status;
+    private final int code;
+    private final String message;
+
+    ErrorCode(int status, int code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/album2me/repost/global/error/ErrorResponse.java
+++ b/src/main/java/com/album2me/repost/global/error/ErrorResponse.java
@@ -1,0 +1,25 @@
+package com.album2me.repost.global.error;
+
+import java.util.List;
+import org.springframework.http.HttpStatus;
+
+public record ErrorResponse(
+        int status,
+        int code,
+        String message,
+        List<FieldException> details
+) {
+    public record FieldException(
+            String fieldName,
+            String inputValue,
+            String reason
+    ){
+        public static FieldException of(String fieldName, String inputValue, String reason){
+            return new FieldException(fieldName, inputValue, reason);
+        }
+    }
+
+    public static ErrorResponse badRequest(ErrorCode errorCode, List<FieldException> details){
+        return new ErrorResponse(errorCode.getStatus(), errorCode.getCode(), errorCode.getMessage(), details);
+    }
+}

--- a/src/main/java/com/album2me/repost/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/album2me/repost/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,35 @@
+package com.album2me.repost.global.error;
+
+import com.album2me.repost.global.error.ErrorResponse.FieldException;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleMethodArgumentNotValidException(MethodArgumentNotValidException e){
+        log.debug("Bad request exception occurred: {}", e.getMessage(), e);
+        List<FieldException> details = createFieldExceptionList(e.getBindingResult());
+        return ErrorResponse.badRequest(ErrorCode.INVALID_ARGUMENT, details);
+    }
+
+    private List<FieldException> createFieldExceptionList(BindingResult bindingResult) {
+        return bindingResult.getFieldErrors().stream().map(fieldError -> FieldException.of(
+                fieldError.getField(),
+                fieldError.getRejectedValue() == null ? null : fieldError.getRejectedValue().toString(),
+                fieldError.getDefaultMessage()))
+                .collect(Collectors.toList());
+    }
+
+}


### PR DESCRIPTION
Close #23 

## 작업 내용
- ErrorCode, ErrorResponse, ErrorHandler 코드 작성
- 유효하지 않은 입력인 INVALID_ARGUMENT 정의
- MethodArgumentNotValidException에 대한 예외 처리 적용

## 고민한 내용
- 응답에 어떤 값을 내려주는지 고민했습니다. status, code, message 세개에 입력 같은 경우 details를 통해 상세하게 정보를 제공하는 것으로 결정했습니다.

## 참고 사항
다음과 같은 글을 참고했습니다.
- https://developers.kakao.com/docs/latest/ko/reference/rest-api-reference#error-code-common
- https://jaehoney.tistory.com/240
