### PR TITLE
AccessToken 발급 및 로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.4'
+	implementation 'com.auth0:java-jwt:4.4.0'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/album2me/repost/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/album2me/repost/domain/auth/controller/AuthController.java
@@ -1,0 +1,24 @@
+package com.album2me.repost.domain.auth.controller;
+
+import com.album2me.repost.domain.auth.dto.request.AuthenticationRequest;
+import com.album2me.repost.domain.auth.dto.response.AuthenticationResponse;
+import com.album2me.repost.domain.auth.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthService authService;
+    @PostMapping
+    @ResponseStatus(HttpStatus.OK)
+    public AuthenticationResponse login(@RequestBody AuthenticationRequest authenticationRequest){
+        return authService.login(authenticationRequest);
+    }
+}

--- a/src/main/java/com/album2me/repost/domain/auth/dto/request/AuthenticationRequest.java
+++ b/src/main/java/com/album2me/repost/domain/auth/dto/request/AuthenticationRequest.java
@@ -1,0 +1,9 @@
+package com.album2me.repost.domain.auth.dto.request;
+
+
+public record AuthenticationRequest(
+        String authId,
+        String password
+) {
+
+}

--- a/src/main/java/com/album2me/repost/domain/auth/dto/response/AuthenticationResponse.java
+++ b/src/main/java/com/album2me/repost/domain/auth/dto/response/AuthenticationResponse.java
@@ -1,0 +1,7 @@
+package com.album2me.repost.domain.auth.dto.response;
+
+public record AuthenticationResponse(
+        String accessToken
+) {
+
+}

--- a/src/main/java/com/album2me/repost/domain/auth/service/AuthService.java
+++ b/src/main/java/com/album2me/repost/domain/auth/service/AuthService.java
@@ -1,0 +1,27 @@
+package com.album2me.repost.domain.auth.service;
+
+import com.album2me.repost.domain.auth.dto.request.AuthenticationRequest;
+import com.album2me.repost.domain.auth.dto.response.AuthenticationResponse;
+import com.album2me.repost.domain.user.model.User;
+import com.album2me.repost.domain.user.repository.UserRepository;
+import com.album2me.repost.global.config.security.jwt.JwtAuthenticationToken;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+    private final AuthenticationManager authenticationManager;
+
+    public AuthenticationResponse login(AuthenticationRequest authenticationRequest){
+        JwtAuthenticationToken authToken = new JwtAuthenticationToken(authenticationRequest.authId(), authenticationRequest.password());
+        Authentication authentication = authenticationManager.authenticate(authToken);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        return new AuthenticationResponse(String.valueOf(authentication.getDetails()));
+    }
+
+}

--- a/src/main/java/com/album2me/repost/domain/user/controller/UserController.java
+++ b/src/main/java/com/album2me/repost/domain/user/controller/UserController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api")
+@RequestMapping("/api/user")
 @RequiredArgsConstructor
 public class UserController {
     private final UserService userService;

--- a/src/main/java/com/album2me/repost/domain/user/model/User.java
+++ b/src/main/java/com/album2me/repost/domain/user/model/User.java
@@ -8,9 +8,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseTimeColumn {
     @Id
@@ -25,11 +27,13 @@ public class User extends BaseTimeColumn {
 
     @Column(length = 20, unique = true, nullable = false)
     private String nickName;
+    private String role;
 
     @Builder
     protected User(String authId, String password, String nickName) {
         this.authId = authId;
         this.password = password;
         this.nickName = nickName;
+        this.role = "ROLE_USER";
     }
 }

--- a/src/main/java/com/album2me/repost/domain/user/model/User.java
+++ b/src/main/java/com/album2me/repost/domain/user/model/User.java
@@ -30,7 +30,7 @@ public class User extends BaseTimeColumn {
     private String role;
 
     @Builder
-    protected User(String authId, String password, String nickName) {
+    protected User(final String authId, final String password, final String nickName) {
         this.authId = authId;
         this.password = password;
         this.nickName = nickName;

--- a/src/main/java/com/album2me/repost/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/album2me/repost/domain/user/repository/UserRepository.java
@@ -1,9 +1,11 @@
 package com.album2me.repost.domain.user.repository;
 
 import com.album2me.repost.domain.user.model.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByAuthId(String authId);
 }

--- a/src/main/java/com/album2me/repost/domain/user/service/UserService.java
+++ b/src/main/java/com/album2me/repost/domain/user/service/UserService.java
@@ -4,6 +4,7 @@ import com.album2me.repost.domain.user.model.User;
 import com.album2me.repost.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -11,5 +12,11 @@ public class UserService {
     private final UserRepository userRepository;
     public void signUp(User user){
         userRepository.save(user);
+    }
+    @Transactional
+    public User findUserByAuthId(String authId){
+        User user = userRepository.findByAuthId(authId)
+                .orElseThrow(() -> new IllegalArgumentException(""));
+        return user;
     }
 }

--- a/src/main/java/com/album2me/repost/domain/user/service/UserService.java
+++ b/src/main/java/com/album2me/repost/domain/user/service/UserService.java
@@ -13,7 +13,6 @@ public class UserService {
     public void signUp(User user){
         userRepository.save(user);
     }
-    @Transactional
     public User findUserByAuthId(String authId){
         User user = userRepository.findByAuthId(authId)
                 .orElseThrow(() -> new IllegalArgumentException(""));

--- a/src/main/java/com/album2me/repost/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/album2me/repost/global/config/security/SecurityConfig.java
@@ -1,7 +1,13 @@
-package com.album2me.repost.global.config;
+package com.album2me.repost.global.config.security;
 
+import com.album2me.repost.domain.user.service.UserService;
+import com.album2me.repost.global.config.security.jwt.JwtAuthenticationProvider;
+import com.album2me.repost.global.config.security.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -11,6 +17,7 @@ import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
     private static final String API_PREFIX = "/api";
     @Bean
@@ -18,8 +25,8 @@ public class SecurityConfig {
         http
                 .authorizeHttpRequests()
                 .requestMatchers(
-                        API_PREFIX + "/sign-up",
-                        API_PREFIX + "/login"
+                        API_PREFIX + "/user/sign-up",
+                        API_PREFIX + "/auth"
                 ).permitAll()
                 .and()
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
@@ -33,7 +40,18 @@ public class SecurityConfig {
     }
 
     @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration)
+            throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public JwtAuthenticationProvider jwtAuthenticationProvider(UserService userService, JwtProvider jwtProvider, PasswordEncoder passwordEncoder){
+        return new JwtAuthenticationProvider(userService, jwtProvider, passwordEncoder);
     }
 }

--- a/src/main/java/com/album2me/repost/global/config/security/jwt/JwtAuthentication.java
+++ b/src/main/java/com/album2me/repost/global/config/security/jwt/JwtAuthentication.java
@@ -1,0 +1,11 @@
+package com.album2me.repost.global.config.security.jwt;
+
+import com.album2me.repost.domain.user.model.User;
+
+public class JwtAuthentication {
+    private final User user;
+
+    public JwtAuthentication(User user) {
+        this.user = user;
+    }
+}

--- a/src/main/java/com/album2me/repost/global/config/security/jwt/JwtAuthenticationProvider.java
+++ b/src/main/java/com/album2me/repost/global/config/security/jwt/JwtAuthenticationProvider.java
@@ -37,7 +37,7 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
 
     private void checkValidPassword(User user, String credential){
         if(!passwordEncoder.matches(credential, user.getPassword())){
-            throw new IllegalArgumentException("BadCredential");
+            throw new IllegalArgumentException("Bad Credential");
         }
     }
 

--- a/src/main/java/com/album2me/repost/global/config/security/jwt/JwtAuthenticationProvider.java
+++ b/src/main/java/com/album2me/repost/global/config/security/jwt/JwtAuthenticationProvider.java
@@ -1,0 +1,44 @@
+package com.album2me.repost.global.config.security.jwt;
+
+import static org.springframework.security.core.authority.AuthorityUtils.createAuthorityList;
+
+import com.album2me.repost.domain.user.model.User;
+import com.album2me.repost.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationProvider implements AuthenticationProvider {
+    private final UserService userService;
+    private final JwtProvider jwtProvider;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return JwtAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        JwtAuthenticationToken jwtAuthenticationToken = (JwtAuthenticationToken) authentication;
+        return processUserAuthentication(String.valueOf(jwtAuthenticationToken.getPrincipal()),jwtAuthenticationToken.getCredentials());
+    }
+
+    private Authentication processUserAuthentication(String principal, String credential) {
+        User user = userService.findUserByAuthId(principal);
+        checkValidPassword(user, credential);
+        String token = jwtProvider.createAccessToken(user.getAuthId(), user.getRole());
+        JwtAuthenticationToken authenticated = new JwtAuthenticationToken(new JwtAuthentication(user), null, createAuthorityList(user.getRole()));
+        authenticated.setDetails(token);
+        return authenticated;
+    }
+
+    private void checkValidPassword(User user, String credential){
+        if(!passwordEncoder.matches(credential, user.getPassword())){
+            throw new IllegalArgumentException("BadCredential");
+        }
+    }
+
+}

--- a/src/main/java/com/album2me/repost/global/config/security/jwt/JwtAuthenticationToken.java
+++ b/src/main/java/com/album2me/repost/global/config/security/jwt/JwtAuthenticationToken.java
@@ -1,0 +1,39 @@
+package com.album2me.repost.global.config.security.jwt;
+
+import java.util.Collection;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+public class JwtAuthenticationToken extends AbstractAuthenticationToken {
+    private final Object principal;
+    private final String credentials;
+
+    public JwtAuthenticationToken(String principal,
+                                  String credentials) {
+        super(null);
+        super.setAuthenticated(false);
+        this.principal = principal;
+        this.credentials = credentials;
+    }
+
+    public JwtAuthenticationToken(
+            Object principal,
+            String credentials,
+            Collection<? extends GrantedAuthority> authorities) {
+        super(authorities);
+        super.setAuthenticated(true);
+
+        this.principal = principal;
+        this.credentials = credentials;
+    }
+
+    @Override
+    public String getCredentials() {
+        return credentials;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return principal;
+    }
+}

--- a/src/main/java/com/album2me/repost/global/config/security/jwt/JwtProperties.java
+++ b/src/main/java/com/album2me/repost/global/config/security/jwt/JwtProperties.java
@@ -1,0 +1,22 @@
+package com.album2me.repost.global.config.security.jwt;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
+public class JwtProperties {
+    private String issuer;
+    private String clientSecret;
+    private int expirySeconds;
+
+    public JwtProperties(
+            @Value("${jwt.token.issuer}") String issuer,
+            @Value("${jwt.token.client-secret}")String clientSecret,
+            @Value("${jwt.token.expirySeconds}") int expirySeconds) {
+        this.issuer = issuer;
+        this.clientSecret = clientSecret;
+        this.expirySeconds = expirySeconds;
+    }
+}

--- a/src/main/java/com/album2me/repost/global/config/security/jwt/JwtProvider.java
+++ b/src/main/java/com/album2me/repost/global/config/security/jwt/JwtProvider.java
@@ -1,0 +1,33 @@
+package com.album2me.repost.global.config.security.jwt;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTCreator;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTCreationException;
+import com.auth0.jwt.interfaces.Claim;
+import java.util.Collection;
+import java.util.Date;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtProvider {
+    private final JwtProperties jwtProperties;
+    private final Algorithm algorithm;
+
+    public JwtProvider(JwtProperties jwtProperties) {
+        this.jwtProperties = jwtProperties;
+        this.algorithm = Algorithm.HMAC256(jwtProperties.getClientSecret());
+    }
+
+    public String createAccessToken(String authId, String role){
+        String accessToken = JWT.create()
+                .withIssuer(jwtProperties.getIssuer())
+                .withClaim("userKey", authId)
+                .withClaim("role", role)
+                .sign(algorithm);
+        return accessToken;
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,3 +29,10 @@ cloud:
       auto: false
     s3:
       bucket: repost-bucket
+
+jwt:
+  token:
+    header: Authorization
+    issuer: album2me
+    client-secret: ENC(UvtsKp8Ul3wLjWNtyKOf3w==)
+    expirySeconds: 7200


### PR DESCRIPTION
Close #3 

## 작업 내용
- accessToken 발급
- 로그인 기능 구현(Token이 없을 시)
- User 엔티티 role attribute 추가

## 고민한 내용
- 스프링 시큐리티를 사용하면서 항상 UserService 혹은 AuthService가 UserDetailsService를 구현하는 방식을 사용하지 않고 할 수 있는 방법을 고민했습니다. UserDetails을 직접 구현하고, AuthenticationProvider 커스터마이징을 통해 기존 DaoAuthenticationProvider가 UserDetailsService를 호출하는 과정을 유사하게 가져가며 해결했습니다.

## 참고 사항

- accessToken을 통해 로그인이 되는 방식은 아직 구현하지 않았습니다.
- Security를 test 하는 방식에 대해서 공부가 필요합니다.
- 공유앨범의 참여자들에게 권한을 다르게 줄지 같은 권한을 줄지 고민중입니다.
