### PR TITLE
feat : 앨범 전체 조회 기능 구현

### DIFF
--- a/src/main/java/com/album2me/repost/domain/album/controller/AlbumController.java
+++ b/src/main/java/com/album2me/repost/domain/album/controller/AlbumController.java
@@ -1,0 +1,25 @@
+package com.album2me.repost.domain.album.controller;
+
+import com.album2me.repost.domain.album.dto.response.AlbumResponse;
+import com.album2me.repost.domain.album.service.AlbumService;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("api/")
+@RequiredArgsConstructor
+public class AlbumController {
+
+    private final AlbumService albumService;
+
+    @GetMapping
+    public List<AlbumResponse> showAll() {
+        return albumService.showAll();
+    }
+}

--- a/src/main/java/com/album2me/repost/domain/album/dto/response/AlbumResponse.java
+++ b/src/main/java/com/album2me/repost/domain/album/dto/response/AlbumResponse.java
@@ -1,0 +1,28 @@
+package com.album2me.repost.domain.album.dto.response;
+
+import com.album2me.repost.domain.album.model.Album;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import org.springframework.beans.BeanUtils;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AlbumResponse {
+
+    private Long id;
+    private Long roomId;
+    private Long writerId;
+    private String thumbnailUrl;
+    private String name;
+    private Long postCount;
+
+    public static AlbumResponse from(final Album album) {
+        final AlbumResponse albumResponse = new AlbumResponse();
+        BeanUtils.copyProperties(album, albumResponse);
+
+        return albumResponse;
+    }
+}

--- a/src/main/java/com/album2me/repost/domain/album/model/Album.java
+++ b/src/main/java/com/album2me/repost/domain/album/model/Album.java
@@ -1,0 +1,51 @@
+package com.album2me.repost.domain.album.model;
+
+import com.album2me.repost.global.common.BaseTimeColumn;
+import jakarta.persistence.*;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Album extends BaseTimeColumn {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 20, unique = true, nullable = false)
+    private Long roomId;
+
+    @Column(length = 20, unique = true, nullable = false)
+    private Long writerId;
+
+    @Column(length = 30, unique = true, nullable = false)
+    private String name;
+
+    @Column(length = 50)
+    private String thumbnailUrl;
+
+    @Column(length = 20)
+    private Long postCount;
+
+    @Builder
+    public Album(
+            final Long id,
+            final Long roomId,
+            final Long writerId,
+            final String name,
+            final String thumbnailUrl,
+            final Long postCount
+    ) {
+        this.id = id;
+        this.roomId = roomId;
+        this.writerId = writerId;
+        this.name = name;
+        this.thumbnailUrl = thumbnailUrl;
+        this.postCount = postCount;
+    }
+}

--- a/src/main/java/com/album2me/repost/domain/album/repository/AlbumRepository.java
+++ b/src/main/java/com/album2me/repost/domain/album/repository/AlbumRepository.java
@@ -1,0 +1,10 @@
+package com.album2me.repost.domain.album.repository;
+
+import com.album2me.repost.domain.album.model.Album;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AlbumRepository extends JpaRepository<Album, Long> {
+}

--- a/src/main/java/com/album2me/repost/domain/album/service/AlbumService.java
+++ b/src/main/java/com/album2me/repost/domain/album/service/AlbumService.java
@@ -1,0 +1,27 @@
+package com.album2me.repost.domain.album.service;
+
+import com.album2me.repost.domain.album.dto.response.AlbumResponse;
+import com.album2me.repost.domain.album.model.Album;
+import com.album2me.repost.domain.album.repository.AlbumRepository;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class AlbumService {
+
+    private final AlbumRepository albumRepository;
+
+    public List<AlbumResponse> showAll() {
+        final List<Album> albums = albumRepository.findAll();
+
+        return albums.stream()
+                .map(AlbumResponse::from)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/album2me/repost/global/error/ErrorCode.java
+++ b/src/main/java/com/album2me/repost/global/error/ErrorCode.java
@@ -5,8 +5,11 @@ import lombok.Getter;
 @Getter
 public enum ErrorCode {
 
-    //COMMON
-    INVALID_ARGUMENT(400, 1000, "유효하지 않은 입력.");
+    //Common
+    INVALID_ARGUMENT(400, 1000, "유효하지 않은 입력."),
+
+    //Album
+    NOT_FOUND_ALBUM(404, 2000, "앨범을 찾을 수 없습니다.");
 
     private final int status;
     private final int code;


### PR DESCRIPTION
Close #26

## 작업 내용
- 앨범 도메인 작성
- 앨범 전체 조회 기능 구현

## 고민한 내용
- 

## 참고 사항
- 전체 조회 시, 페이징 처리는 아직 적용하지 않은 상태입니다.(이에 따라, 전체 조회 전용 Pageable DTO도 추후에 정의할 계획입니다.)
- ERD에 작성한 컬럼명들 중 수정사항이 있습니다. (사진 개수 : posts_count -> post_count, 댓글 개수 : comments_count -> comment_count)