### PR TITLE
feat : 앨범 수정 및 삭제 기능 구현

### DIFF
--- a/src/main/java/com/album2me/repost/domain/album/controller/AlbumController.java
+++ b/src/main/java/com/album2me/repost/domain/album/controller/AlbumController.java
@@ -42,4 +42,12 @@ public class AlbumController {
         return ResponseEntity.noContent()
                 .build();
     }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable final Long id) {
+        albumService.delete(id);
+
+        return ResponseEntity.noContent()
+                .build();
+    }
 }

--- a/src/main/java/com/album2me/repost/domain/album/controller/AlbumController.java
+++ b/src/main/java/com/album2me/repost/domain/album/controller/AlbumController.java
@@ -31,4 +31,15 @@ public class AlbumController {
         return ResponseEntity.created(URI.create("api/albums" + albumId))
                 .build();
     }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Void> update(
+            @PathVariable final Long id,
+            @RequestBody final AlbumRequest albumRequest
+    ) {
+        albumService.update(id, albumRequest);
+
+        return ResponseEntity.noContent()
+                .build();
+    }
 }

--- a/src/main/java/com/album2me/repost/domain/album/dto/request/AlbumRequest.java
+++ b/src/main/java/com/album2me/repost/domain/album/dto/request/AlbumRequest.java
@@ -8,20 +8,14 @@ import lombok.*;
 @AllArgsConstructor
 public class AlbumRequest {
 
-    private Long roomId;
-    private Long writerId;
-    private String thumbnailUrl;
     private String name;
-    private Long postCount;
+    private String thumbnailUrl;
 
     @Builder
     public Album toEntity() {
         return Album.builder()
-                .roomId(roomId)
-                .writerId(writerId)
-                .thumbnailUrl(thumbnailUrl)
                 .name(name)
-                .postCount(postCount)
+                .thumbnailUrl(thumbnailUrl)
                 .build();
     }
 }

--- a/src/main/java/com/album2me/repost/domain/album/model/Album.java
+++ b/src/main/java/com/album2me/repost/domain/album/model/Album.java
@@ -48,4 +48,21 @@ public class Album extends BaseTimeColumn {
         this.thumbnailUrl = thumbnailUrl;
         this.postCount = postCount;
     }
+
+    public void update(final Album album) {
+        updateName(album.getName());
+        updateThumbnail(album.getThumbnailUrl());
+    }
+
+    private void updateName(final String name) {
+        if (name != null) {
+            this.name = name;
+        }
+    }
+
+    private void updateThumbnail(final String thumbnailUrl) {
+        if (thumbnailUrl != null) {
+            this.thumbnailUrl = thumbnailUrl;
+        }
+    }
 }

--- a/src/main/java/com/album2me/repost/domain/album/service/AlbumService.java
+++ b/src/main/java/com/album2me/repost/domain/album/service/AlbumService.java
@@ -35,12 +35,18 @@ public class AlbumService {
     }
 
     @Transactional
-    public AlbumResponse update(final Long id, final AlbumRequest albumRequest) {
+    public void update(final Long id, final AlbumRequest albumRequest) {
         final Album album = albumRepository.findById(id)
                 .orElseThrow(IllegalArgumentException::new);
 
         album.update(albumRequest.toEntity());
+    }
 
-        return AlbumResponse.from(album);
+    @Transactional
+    public void delete(final Long id) {
+        final Album album = albumRepository.findById(id)
+                .orElseThrow(IllegalArgumentException::new);
+
+        albumRepository.delete(album);
     }
 }

--- a/src/main/java/com/album2me/repost/domain/album/service/AlbumService.java
+++ b/src/main/java/com/album2me/repost/domain/album/service/AlbumService.java
@@ -33,4 +33,14 @@ public class AlbumService {
 
         return AlbumResponse.from(newAlbum);
     }
+
+    @Transactional
+    public AlbumResponse update(final Long id, final AlbumRequest albumRequest) {
+        final Album album = albumRepository.findById(id)
+                .orElseThrow(IllegalArgumentException::new);
+
+        album.update(albumRequest.toEntity());
+
+        return AlbumResponse.from(album);
+    }
 }


### PR DESCRIPTION
close #8 

## 작업 내용
- 앨범 수정 기능 구현
- 앨범 삭제 기능 구현

## 고민한 내용
🤔 **앨범 수정 책임 에 대해 고민했습니다.**

앨범을 수정할 때, 실질적인 처리를 service와 domain 중 어디서 구현해야 할 지 고민했습니다.
Information Expert 패턴에서, "책임을 수행하는 데 필요한 정보를 가진 객체에게 할당하라" 라는 원칙을 떠올려
앨범 도메인에서 실질적인 업데이트 책임을 부여하였습니다.

## 참고 사항
- API 명세서에서 앨범, 포스트의 수정/삭제의 **성공 status code는 모두 204(No Content)로 수정**하였습니다.