### PR TITLE
feat: S3 이미지 업로드 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.4'
 	implementation 'com.auth0:java-jwt:4.4.0'
+	implementation 'javax.xml.bind:jaxb-api:2.3.1'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/album2me/repost/domain/auth/service/AuthService.java
+++ b/src/main/java/com/album2me/repost/domain/auth/service/AuthService.java
@@ -2,15 +2,12 @@ package com.album2me.repost.domain.auth.service;
 
 import com.album2me.repost.domain.auth.dto.request.AuthenticationRequest;
 import com.album2me.repost.domain.auth.dto.response.AuthenticationResponse;
-import com.album2me.repost.domain.user.model.User;
-import com.album2me.repost.domain.user.repository.UserRepository;
 import com.album2me.repost.global.config.security.jwt.JwtAuthenticationToken;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/album2me/repost/domain/image/controller/ImageController.java
+++ b/src/main/java/com/album2me/repost/domain/image/controller/ImageController.java
@@ -1,0 +1,27 @@
+package com.album2me.repost.domain.image.controller;
+
+import com.album2me.repost.domain.image.dto.UploadImageRequest;
+import com.album2me.repost.domain.image.dto.UploadImageResponse;
+import com.album2me.repost.domain.image.service.ImageService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/image")
+@RequiredArgsConstructor
+public class ImageController {
+    private final ImageService imageService;
+    @PostMapping
+    @ResponseStatus(HttpStatus.OK)
+    public UploadImageResponse uploadImage(@ModelAttribute @Valid UploadImageRequest uploadImageRequest) {
+        UploadImageResponse uploadImageResponse = imageService.uploadImage(uploadImageRequest);
+        return uploadImageResponse;
+    }
+}

--- a/src/main/java/com/album2me/repost/domain/image/controller/ImageController.java
+++ b/src/main/java/com/album2me/repost/domain/image/controller/ImageController.java
@@ -6,7 +6,6 @@ import com.album2me.repost.domain.image.service.ImageService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/src/main/java/com/album2me/repost/domain/image/dto/UploadImageRequest.java
+++ b/src/main/java/com/album2me/repost/domain/image/dto/UploadImageRequest.java
@@ -1,0 +1,10 @@
+package com.album2me.repost.domain.image.dto;
+
+import jakarta.validation.constraints.NotNull;
+import org.springframework.web.multipart.MultipartFile;
+
+public record UploadImageRequest(
+        @NotNull(message = "파일이 존재하지 않습니다.")
+        MultipartFile image
+) {
+}

--- a/src/main/java/com/album2me/repost/domain/image/dto/UploadImageResponse.java
+++ b/src/main/java/com/album2me/repost/domain/image/dto/UploadImageResponse.java
@@ -1,0 +1,6 @@
+package com.album2me.repost.domain.image.dto;
+
+public record UploadImageResponse(
+        String imageUrl
+) {
+}

--- a/src/main/java/com/album2me/repost/domain/image/service/ImageService.java
+++ b/src/main/java/com/album2me/repost/domain/image/service/ImageService.java
@@ -1,0 +1,36 @@
+package com.album2me.repost.domain.image.service;
+
+import static com.album2me.repost.global.common.AttachedFile.toAttachedFile;
+
+import com.album2me.repost.domain.image.dto.UploadImageRequest;
+import com.album2me.repost.domain.image.dto.UploadImageResponse;
+import com.album2me.repost.global.common.AttachedFile;
+import com.album2me.repost.infra.s3.AwsS3Service;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+    private final AwsS3Service awsS3Service;
+
+    public UploadImageResponse uploadImage(UploadImageRequest uploadImageRequest){
+        AttachedFile attachedFile = getAttachedFile(uploadImageRequest.image());
+        String imageUrl;
+        try{
+            imageUrl = awsS3Service.uploadImage(attachedFile);
+        } catch (AmazonS3Exception e) {
+            throw new RuntimeException("");
+        }
+        return new UploadImageResponse(imageUrl);
+    }
+
+    private AttachedFile getAttachedFile(MultipartFile multipartFile) {
+        return toAttachedFile("profile", multipartFile).orElseThrow(IllegalArgumentException::new);
+    }
+
+}

--- a/src/main/java/com/album2me/repost/global/common/AttachedFile.java
+++ b/src/main/java/com/album2me/repost/global/common/AttachedFile.java
@@ -1,0 +1,60 @@
+package com.album2me.repost.global.common;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.Getter;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+public class AttachedFile {
+    private static final String UNIX_SEPARATOR = "/";
+    private static final String EXTENSION_SEPARATOR = ".";
+    private static final String DEFAULT_EXTENSION = "jpeg";
+    private final String fileName;
+    private final InputStream inputStream;
+    private final String contentType;
+    private final long contentLength;
+
+    public AttachedFile(String fileName, InputStream inputStream, String contentType, long contentLength) {
+        this.fileName = fileName;
+        this.inputStream = inputStream;
+        this.contentType = contentType;
+        this.contentLength = contentLength;
+    }
+
+    public static Optional<AttachedFile> toAttachedFile(String basePath, MultipartFile multipartFile) {
+        try{
+            if(verify(multipartFile)){
+                String generatedFileName = generateRandomName(basePath, multipartFile.getOriginalFilename());
+                return Optional.of(new AttachedFile(
+                        generatedFileName, multipartFile.getInputStream(), multipartFile.getContentType(), multipartFile.getSize())
+                );
+            }
+        } catch (IOException e) {
+            throw new IllegalArgumentException("");
+        }
+        return Optional.empty();
+    }
+
+    private static boolean verify(MultipartFile multipartFile) {
+        if(multipartFile != null && multipartFile.getSize() > 0 && multipartFile.getOriginalFilename() != null) {
+            String contentType = multipartFile.getContentType();
+            return !contentType.isEmpty() && contentType.toLowerCase().startsWith("image");
+        }
+        return false;
+    }
+
+    private static String generateRandomName(String bathPath, String originalName) {
+        String fileName = bathPath + UNIX_SEPARATOR + UUID.randomUUID()
+                + EXTENSION_SEPARATOR + getExtension(originalName);
+        return fileName;
+    }
+
+    private static String getExtension(String originalName) {
+        String extension = StringUtils.getFilenameExtension(originalName);
+        return extension.isEmpty() ? DEFAULT_EXTENSION : extension;
+    }
+}

--- a/src/main/java/com/album2me/repost/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/album2me/repost/global/config/security/SecurityConfig.java
@@ -26,7 +26,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests()
                 .requestMatchers(
                         API_PREFIX + "/user/sign-up",
-                        API_PREFIX + "/auth"
+                        API_PREFIX + "/auth",
+                        API_PREFIX + "/image"
                 ).permitAll()
                 .and()
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)

--- a/src/main/java/com/album2me/repost/infra/s3/AwsS3Service.java
+++ b/src/main/java/com/album2me/repost/infra/s3/AwsS3Service.java
@@ -1,0 +1,42 @@
+package com.album2me.repost.infra.s3;
+
+import com.album2me.repost.global.common.AttachedFile;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AwsS3Service {
+    private static final String UNIX_SEPARATOR = "/";
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+    @Value("${cloud.aws.s3.url}")
+    private String url;
+    private final AmazonS3 amazonS3;
+
+    public String uploadImage(AttachedFile file) {
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentType(file.getContentType());
+        objectMetadata.setContentLength(file.getContentLength());
+        PutObjectRequest putObjectRequest = new PutObjectRequest(bucketName, file.getFileName(), file.getInputStream(), objectMetadata);
+        amazonS3.putObject(putObjectRequest.withCannedAcl(CannedAccessControlList.PublicRead));
+        return generateUrl(file.getFileName());
+    }
+
+    private String generateUrl(String fileName) {
+        StringBuilder sb = new StringBuilder(url);
+        if (!url.endsWith(UNIX_SEPARATOR))
+            sb.append(UNIX_SEPARATOR);
+        sb.append(bucketName);
+        sb.append(UNIX_SEPARATOR);
+        sb.append(fileName);
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/album2me/repost/infra/s3/S3Config.java
+++ b/src/main/java/com/album2me/repost/infra/s3/S3Config.java
@@ -1,4 +1,4 @@
-package com.album2me.repost.global.config;
+package com.album2me.repost.infra.s3;
 
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
@@ -13,8 +13,10 @@ import org.springframework.context.annotation.Configuration;
 public class S3Config {
     @Value("${cloud.aws.credentials.access-key}")
     private String accessKey;
+
     @Value("${cloud.aws.credentials.secret-key}")
     private String secretKey;
+
     @Value("${cloud.aws.region.static}")
     private String region;
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,7 +20,7 @@ jasypt:
 cloud:
   aws:
     credentials:
-      access-key: ENC(8B4jjzbIeDQaVS8CMhrMXCA/z3P/1/SsAWOx3CSx4jk=)
+      access-key: ENC(VY834y5nhBS8+gvjF0nWF9Bs/wV4AVcsSVqSj9iDvxI=)
       secret-key: ENC(FR8m+0neWo11YVjxtQl8qDzDb/OvUUHwqy1evCgNeVpMA5HVvqLWf7vzQnQ6FjO/d/mDVNFYmRg=)
     region:
       static: ap-northeast-2

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,6 +28,7 @@ cloud:
     stack:
       auto: false
     s3:
+      url: https://s3.ap-northeast-2.amazonaws.com
       bucket: repost-bucket
 
 jwt:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,9 @@ spring:
     properties:
       hibernate:
         show_sql: true
+  servlet:
+    multipart:
+      max-file-size: 50MB
 
 jasypt:
   encryptor:


### PR DESCRIPTION
## 작업 내용
- AWS S3 이미지 업로드 기능 구현
- 이미지 controller 구현
- AttachedFile 객체 구현

## 고민한 내용
- 이미지에 대한 controller를 따로 만드는 것에 대해 고민했습니다. Request에서 이미지 파일의 형식만 다르게 주어야 하다보니 form-data와 json 형식이 혼합된 방식을 사용하거나, json 파일로 보내질 데이터가 form-data의 key value 형식으로 보내지게 되는 방식을 사용해야합니다.  
따라서 우선적으로 이미지만 업로드해 image url을 응답한다면 이후 클라이언트에서 json 형식으로 통일되게 request를 보낼 수 있을 것이라 생각해 이미지 업로드 용 controller를 따로 구현하였습니다.
- 파일에 대한 검증 부분을 좀 고민했습니다. 더 신경써야할 부분이 있다면 피드백 부탁드려요.

## 참고 사항
- AttachedFile 객체는 Multipart에 대한 검증 및 파일을 통한 s3 데이터 생성에 대한 역할을 수행합니다.
- 적절한 에러핸들링이 되어있지 않습니다. 추후 회의에서 에러코드 재정의 후 수정하겠습니다.
- imageservice에 "profile" 이라고 되어있는 부분은 이미지를 업로드 할때 profile이면 profile, post면 post 별로 s3에서 폴더를 구별하기 위해 썼는데 이렇게 되면 클라이언트에서 구분을 해주는 값을 보내야해서 논의가 필요합니다.
