### PR TITLE
Refactor : 프로젝트 전체에서 에러 관리 방식을 결정

### DIFF
--- a/src/main/java/com/album2me/repost/domain/album/controller/AlbumController.java
+++ b/src/main/java/com/album2me/repost/domain/album/controller/AlbumController.java
@@ -1,9 +1,13 @@
 package com.album2me.repost.domain.album.controller;
 
-import com.album2me.repost.domain.album.dto.request.AlbumRequest;
+import com.album2me.repost.domain.album.dto.request.AlbumCreateRequest;
+import com.album2me.repost.domain.album.dto.request.AlbumUpdateRequest;
 import com.album2me.repost.domain.album.dto.response.AlbumResponse;
 import com.album2me.repost.domain.album.service.AlbumService;
+import com.album2me.repost.domain.auth.controller.VerifiedUser;
+import com.album2me.repost.domain.user.model.User;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.ResponseEntity;
@@ -25,8 +29,11 @@ public class AlbumController {
     }
 
     @PostMapping
-    public ResponseEntity<Void> create(@RequestBody final AlbumRequest albumRequest) {
-        final Long albumId = albumService.create(albumRequest).getId();
+    public ResponseEntity<Void> create(
+            @VerifiedUser User user,
+            @Valid @RequestBody final AlbumCreateRequest albumCreateRequest
+    ) {
+        final Long albumId = albumService.create(user.getId(), albumCreateRequest);
 
         return ResponseEntity.created(URI.create("api/albums" + albumId))
                 .build();
@@ -35,19 +42,24 @@ public class AlbumController {
     @PutMapping("/{id}")
     public ResponseEntity<Void> update(
             @PathVariable final Long id,
-            @RequestBody final AlbumRequest albumRequest
+            @VerifiedUser User user,
+            @Valid @RequestBody final AlbumUpdateRequest albumUpdateRequest
     ) {
-        albumService.update(id, albumRequest);
+        albumService.update(id, albumUpdateRequest);
 
-        return ResponseEntity.noContent()
-                .build();
+        return ResponseEntity.ok()
+            .build();
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> delete(@PathVariable final Long id) {
+    public ResponseEntity<Void> delete(
+            @PathVariable final Long id,
+            @VerifiedUser User user
+    ) {
+
         albumService.delete(id);
 
-        return ResponseEntity.noContent()
+        return ResponseEntity.ok()
                 .build();
     }
 }

--- a/src/main/java/com/album2me/repost/domain/album/dto/request/AlbumCreateRequest.java
+++ b/src/main/java/com/album2me/repost/domain/album/dto/request/AlbumCreateRequest.java
@@ -1,0 +1,29 @@
+package com.album2me.repost.domain.album.dto.request;
+
+import com.album2me.repost.domain.album.model.Album;
+import com.album2me.repost.domain.room.model.Room;
+import com.album2me.repost.domain.user.model.User;
+
+import jakarta.validation.constraints.NotNull;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class AlbumCreateRequest {
+
+    @NotNull(message = "방이 없습니다.")
+    private Long roomId;
+    @NotNull(message = "이름이 없습니다.")
+    private String name;
+
+    @Builder
+    public Album toEntity(final User user, final Room room) {
+        return Album.builder()
+                .user(user)
+                .room(room)
+                .name(name)
+                .build();
+    }
+}

--- a/src/main/java/com/album2me/repost/domain/album/dto/request/AlbumUpdateRequest.java
+++ b/src/main/java/com/album2me/repost/domain/album/dto/request/AlbumUpdateRequest.java
@@ -1,14 +1,17 @@
 package com.album2me.repost.domain.album.dto.request;
 
 import com.album2me.repost.domain.album.model.Album;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class AlbumRequest {
+public class AlbumUpdateRequest {
 
+    @NotNull(message = "앨범명이 입력되지 않았습니다.")
     private String name;
+
     private String thumbnailUrl;
 
     @Builder

--- a/src/main/java/com/album2me/repost/domain/album/model/Album.java
+++ b/src/main/java/com/album2me/repost/domain/album/model/Album.java
@@ -1,5 +1,7 @@
 package com.album2me.repost.domain.album.model;
 
+import com.album2me.repost.domain.room.model.Room;
+import com.album2me.repost.domain.user.model.User;
 import com.album2me.repost.global.common.BaseTimeColumn;
 import jakarta.persistence.*;
 
@@ -15,13 +17,16 @@ public class Album extends BaseTimeColumn {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "album_id")
     private Long id;
 
-    @Column(length = 20, unique = true, nullable = false)
-    private Long roomId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id", nullable = false)
+    private Room room;
 
-    @Column(length = 20, unique = true, nullable = false)
-    private Long writerId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
     @Column(length = 30, unique = true, nullable = false)
     private String name;
@@ -29,21 +34,21 @@ public class Album extends BaseTimeColumn {
     @Column(length = 50)
     private String thumbnailUrl;
 
-    @Column(length = 20)
-    private Long postCount;
+    @Column(length = 20, nullable = false)
+    private int postCount;
 
     @Builder
     public Album(
             final Long id,
-            final Long roomId,
-            final Long writerId,
+            final Room room,
+            final User user,
             final String name,
             final String thumbnailUrl,
-            final Long postCount
+            final int postCount
     ) {
         this.id = id;
-        this.roomId = roomId;
-        this.writerId = writerId;
+        this.room = room;
+        this.user = user;
         this.name = name;
         this.thumbnailUrl = thumbnailUrl;
         this.postCount = postCount;

--- a/src/main/java/com/album2me/repost/domain/album/model/Album.java
+++ b/src/main/java/com/album2me/repost/domain/album/model/Album.java
@@ -1,5 +1,6 @@
 package com.album2me.repost.domain.album.model;
 
+import com.album2me.repost.domain.post.model.Post;
 import com.album2me.repost.domain.room.model.Room;
 import com.album2me.repost.domain.user.model.User;
 import com.album2me.repost.global.common.BaseTimeColumn;
@@ -9,6 +10,9 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -27,6 +31,9 @@ public class Album extends BaseTimeColumn {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
+
+    @OneToMany(mappedBy = "album", cascade = CascadeType.REMOVE)
+    private List<Post> posts = new ArrayList<>();
 
     @Column(length = 30, unique = true, nullable = false)
     private String name;

--- a/src/main/java/com/album2me/repost/domain/album/service/AlbumService.java
+++ b/src/main/java/com/album2me/repost/domain/album/service/AlbumService.java
@@ -1,9 +1,14 @@
 package com.album2me.repost.domain.album.service;
 
-import com.album2me.repost.domain.album.dto.request.AlbumRequest;
+import com.album2me.repost.domain.album.dto.request.AlbumCreateRequest;
+import com.album2me.repost.domain.album.dto.request.AlbumUpdateRequest;
 import com.album2me.repost.domain.album.dto.response.AlbumResponse;
 import com.album2me.repost.domain.album.model.Album;
 import com.album2me.repost.domain.album.repository.AlbumRepository;
+import com.album2me.repost.domain.room.model.Room;
+import com.album2me.repost.domain.room.repository.RoomRepository;
+import com.album2me.repost.domain.user.model.User;
+import com.album2me.repost.domain.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -11,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
 @Service
@@ -18,6 +24,8 @@ import java.util.stream.Collectors;
 public class AlbumService {
 
     private final AlbumRepository albumRepository;
+    private final UserRepository userRepository;
+    private final RoomRepository roomRepository;
 
     public List<AlbumResponse> showAll() {
         final List<Album> albums = albumRepository.findAll();
@@ -28,10 +36,20 @@ public class AlbumService {
     }
 
     @Transactional
-    public AlbumResponse create(final AlbumRequest albumRequest) {
-        final Album newAlbum = albumRepository.save(albumRequest.toEntity());
+    public Long create(final Long userId, final AlbumCreateRequest albumCreateRequest) {
+        final User user = findUserById(userId);
+        final Room room = findRoomById(albumCreateRequest.getRoomId());
 
-        return AlbumResponse.from(newAlbum);
+        final Long albumId = createAlbum(user, room, albumCreateRequest);
+
+        return albumId;
+    }
+
+    private Long createAlbum(final User user, final Room room, final AlbumCreateRequest albumCreateRequest) {
+        final Album newAlbum = albumCreateRequest.toEntity(user, room);
+
+        return albumRepository.save(newAlbum)
+                .getId();
     }
 
     @Transactional
@@ -48,5 +66,20 @@ public class AlbumService {
                 .orElseThrow(IllegalArgumentException::new);
 
         albumRepository.delete(album);
+    }
+
+    private User findUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new NoSuchElementException("해당 id로 User를 찾을 수 없습니다."));
+    }
+
+    private Room findRoomById(Long roomId) {
+        return roomRepository.findById(roomId)
+                .orElseThrow(() -> new NoSuchElementException("해당 id로 Room을 찾을 수 없습니다."));
+    }
+
+    private Album findAlbumById(Long albumId) {
+        return albumRepository.findById(albumId)
+                .orElseThrow(() -> new NoSuchElementException("해당 id로 Album을 찾을 수 없습니다."));
     }
 }

--- a/src/main/java/com/album2me/repost/domain/album/service/AlbumService.java
+++ b/src/main/java/com/album2me/repost/domain/album/service/AlbumService.java
@@ -11,7 +11,6 @@ import com.album2me.repost.domain.user.model.User;
 import com.album2me.repost.domain.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -53,17 +52,15 @@ public class AlbumService {
     }
 
     @Transactional
-    public void update(final Long id, final AlbumRequest albumRequest) {
-        final Album album = albumRepository.findById(id)
-                .orElseThrow(IllegalArgumentException::new);
+    public void update(final Long id, final AlbumUpdateRequest albumUpdateRequest) {
+        final Album album = findAlbumById(id);
 
-        album.update(albumRequest.toEntity());
+        album.update(albumUpdateRequest.toEntity());
     }
 
     @Transactional
     public void delete(final Long id) {
-        final Album album = albumRepository.findById(id)
-                .orElseThrow(IllegalArgumentException::new);
+        final Album album = findAlbumById(id);
 
         albumRepository.delete(album);
     }

--- a/src/main/java/com/album2me/repost/domain/auth/controller/VerifiedUser.java
+++ b/src/main/java/com/album2me/repost/domain/auth/controller/VerifiedUser.java
@@ -1,0 +1,11 @@
+package com.album2me.repost.domain.auth.controller;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface VerifiedUser {
+}

--- a/src/main/java/com/album2me/repost/domain/comment/domain/Comment.java
+++ b/src/main/java/com/album2me/repost/domain/comment/domain/Comment.java
@@ -1,0 +1,21 @@
+package com.album2me.repost.domain.comment.domain;
+
+import com.album2me.repost.domain.post.model.Post;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+}

--- a/src/main/java/com/album2me/repost/domain/post/controller/PostController.java
+++ b/src/main/java/com/album2me/repost/domain/post/controller/PostController.java
@@ -5,7 +5,7 @@ import com.album2me.repost.domain.post.service.PostService;
 
 import lombok.RequiredArgsConstructor;
 
-import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -16,9 +16,10 @@ public class PostController {
     private final PostService postService;
 
     @GetMapping("/{id}")
-    @ResponseStatus(HttpStatus.OK)
-    public PostResponse show(@PathVariable final Long id) {
+    public ResponseEntity<PostResponse> show(@PathVariable final Long id) {
 
-        return postService.findById(id);
+        return ResponseEntity.ok(
+                postService.findById(id)
+        );
     }
 }

--- a/src/main/java/com/album2me/repost/domain/post/model/Post.java
+++ b/src/main/java/com/album2me/repost/domain/post/model/Post.java
@@ -1,31 +1,46 @@
 package com.album2me.repost.domain.post.model;
 
+import com.album2me.repost.domain.album.model.Album;
+import com.album2me.repost.domain.comment.domain.Comment;
+import com.album2me.repost.domain.user.model.User;
+import com.album2me.repost.global.common.BaseTimeColumn;
+
 import jakarta.persistence.*;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import org.hibernate.annotations.ColumnDefault;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Post {
+public class Post extends BaseTimeColumn {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, updatable = false)
-    private Long roomId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "album_id", nullable = false)
+    private Album album;
 
-    @Column(nullable = false)
-    private Long writerId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 100)
     private String title;
 
+    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
+    private List<Comment> comments = new ArrayList<>();
+
+    @Column(length = 200)
     private String contents;
 
     @Column(length = 10)
@@ -34,4 +49,25 @@ public class Post {
     @Column(length = 1)
     @ColumnDefault("false")
     private boolean isFavorite;
+
+    @Builder
+    public Post (
+            final Long id,
+            final Album album,
+            final User user,
+            final String title,
+            final String contents,
+            final Long commentCount,
+            final boolean isFavorite
+    ) {
+        this.id = id;
+        this.album = album;
+        this.user = user;
+        this.title = title;
+        this.contents = contents;
+        this.commentCount = commentCount;
+        this.isFavorite = isFavorite;
+   }
 }
+
+

--- a/src/main/java/com/album2me/repost/domain/room/model/Room.java
+++ b/src/main/java/com/album2me/repost/domain/room/model/Room.java
@@ -1,0 +1,21 @@
+package com.album2me.repost.domain.room.model;
+
+import com.album2me.repost.global.common.BaseTimeColumn;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Room extends BaseTimeColumn {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+}

--- a/src/main/java/com/album2me/repost/domain/room/repository/RoomRepository.java
+++ b/src/main/java/com/album2me/repost/domain/room/repository/RoomRepository.java
@@ -1,0 +1,9 @@
+package com.album2me.repost.domain.room.repository;
+
+import com.album2me.repost.domain.room.model.Room;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RoomRepository extends JpaRepository<Room, Long> {
+}

--- a/src/main/java/com/album2me/repost/global/error/ErrorCode.java
+++ b/src/main/java/com/album2me/repost/global/error/ErrorCode.java
@@ -7,9 +7,7 @@ public enum ErrorCode {
 
     //Common
     INVALID_ARGUMENT(400, 1000, "유효하지 않은 입력."),
-
-    //Album
-    NOT_FOUND_ALBUM(404, 2000, "앨범을 찾을 수 없습니다.");
+    NOT_FOUND(404, 2000, "요청한 리소스를 찾을 수 없음.");
 
     private final int status;
     private final int code;

--- a/src/main/java/com/album2me/repost/global/error/ErrorResponse.java
+++ b/src/main/java/com/album2me/repost/global/error/ErrorResponse.java
@@ -21,4 +21,8 @@ public record ErrorResponse(
     public static ErrorResponse badRequest(ErrorCode errorCode, List<FieldException> details){
         return new ErrorResponse(errorCode.getStatus(), errorCode.getCode(), errorCode.getMessage(), details);
     }
+
+    public static ErrorResponse notFound(ErrorCode errorCode) {
+        return new ErrorResponse(errorCode.getStatus(), errorCode.getCode(), errorCode.getMessage(), null);
+    }
 }

--- a/src/main/java/com/album2me/repost/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/album2me/repost/global/error/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.album2me.repost.global.error;
 
 import com.album2me.repost.global.error.ErrorResponse.FieldException;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -21,6 +22,13 @@ public class GlobalExceptionHandler {
         log.debug("Bad request exception occurred: {}", e.getMessage(), e);
         List<FieldException> details = createFieldExceptionList(e.getBindingResult());
         return ErrorResponse.badRequest(ErrorCode.INVALID_ARGUMENT, details);
+    }
+
+    @ExceptionHandler(NoSuchElementException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ErrorResponse handleNoSuchElementException(NoSuchElementException e) {
+        log.debug("Not Found exception occurred: {}", e.getMessage(), e);
+        return ErrorResponse.notFound(ErrorCode.NOT_FOUND);
     }
 
     private List<FieldException> createFieldExceptionList(BindingResult bindingResult) {


### PR DESCRIPTION
close #30

## 작업 내용
- Album, Post 연관관계 매핑
- API 변경사항 적용(Status 코드 등)
- DTO 분리

## 고민한 내용
🤔 Entity가 Dto를 가져도 되는지에 대해서 고민했습니다. 특히 Album이 여러 Post를, 한 Post에서 여러 Comments를 가질 때, 해당 리스트의 타입(List<T>)를 Entity를 사용해야 할지, VO를 사용해야 할지 고민이 되었는데요, 제 생각에는 Entity는 가급적 어느 것에도 의존하지 않는 것이 좋다고 생각되어 별도의 Dto 대신 Entity를 직접 사용했습니다. 

이에 대한 지환님의 생각을 듣고 싶습니다!

🤔 커스텀 에러 코드에 대해 고민했습니다.

https://tecoble.techcourse.co.kr/post/2020-08-17-custom-exception/
albumService에서 id값을 이용해 repository에서 조회하는 로직이 있습니다. 해당 부분에서 NotFoundException을 처리하기 위해 커스텀 에러를 사용할지 고민했는데요, 결론은 `java.util`의 `NoSuchElementException` 을 이용하고, 에러메세지를 통해 명확한 메세지를 전달하도록 작성했습니다. 만약 domain의 개수가 늘어나면, 그에 따라 커스텀 에러를 계속해서 작성해야 하는 번거로움을 줄이기 위함입니다.

## 참고 사항
- 각 기능별로 명확한 권한의 정의가 필요할 것 같습니다! 코드를 작성하다 보니 모호한 부분이 많다고 느껴지네요.
- @VerifiedUser 어노테이션을 정의했습니다! 더 필요한 설정이 있다면 추가로 작성해주시면 좋을 것 같습니다.