### PR TITLE
feat : 포스트 수정 기능 구현

### DIFF
--- a/src/main/java/com/album2me/repost/domain/album/controller/AlbumController.java
+++ b/src/main/java/com/album2me/repost/domain/album/controller/AlbumController.java
@@ -30,7 +30,7 @@ public class AlbumController {
 
     @PostMapping
     public ResponseEntity<Void> create(
-            @VerifiedUser User user,
+            @VerifiedUser final User user,
             @Valid @RequestBody final AlbumCreateRequest albumCreateRequest
     ) {
         final Long albumId = albumService.create(user.getId(), albumCreateRequest);
@@ -42,7 +42,7 @@ public class AlbumController {
     @PutMapping("/{id}")
     public ResponseEntity<Void> update(
             @PathVariable final Long id,
-            @VerifiedUser User user,
+            @VerifiedUser final User user,
             @Valid @RequestBody final AlbumUpdateRequest albumUpdateRequest
     ) {
         albumService.update(id, albumUpdateRequest);

--- a/src/main/java/com/album2me/repost/domain/album/dto/request/AlbumCreateRequest.java
+++ b/src/main/java/com/album2me/repost/domain/album/dto/request/AlbumCreateRequest.java
@@ -6,19 +6,11 @@ import com.album2me.repost.domain.user.model.User;
 
 import jakarta.validation.constraints.NotNull;
 
-import lombok.*;
+public record AlbumCreateRequest (
+    @NotNull(message = "방이 없습니다.") Long roomId,
+    @NotNull(message = "이름이 없습니다.") String name
+) {
 
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-public class AlbumCreateRequest {
-
-    @NotNull(message = "방이 없습니다.")
-    private Long roomId;
-    @NotNull(message = "이름이 없습니다.")
-    private String name;
-
-    @Builder
     public Album toEntity(final User user, final Room room) {
         return Album.builder()
                 .user(user)

--- a/src/main/java/com/album2me/repost/domain/album/dto/request/AlbumUpdateRequest.java
+++ b/src/main/java/com/album2me/repost/domain/album/dto/request/AlbumUpdateRequest.java
@@ -2,19 +2,13 @@ package com.album2me.repost.domain.album.dto.request;
 
 import com.album2me.repost.domain.album.model.Album;
 import jakarta.validation.constraints.NotNull;
-import lombok.*;
 
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-public class AlbumUpdateRequest {
+public record AlbumUpdateRequest (
+    @NotNull(message = "앨범명이 입력되지 않았습니다.") String name,
+    String thumbnailUrl
 
-    @NotNull(message = "앨범명이 입력되지 않았습니다.")
-    private String name;
+) {
 
-    private String thumbnailUrl;
-
-    @Builder
     public Album toEntity() {
         return Album.builder()
                 .name(name)

--- a/src/main/java/com/album2me/repost/domain/album/dto/response/AlbumResponse.java
+++ b/src/main/java/com/album2me/repost/domain/album/dto/response/AlbumResponse.java
@@ -3,9 +3,9 @@ package com.album2me.repost.domain.album.dto.response;
 import com.album2me.repost.domain.album.model.Album;
 
 public record AlbumResponse (
-        Long id,
-        String thumbnailUrl,
-        String name
+    Long id,
+    String thumbnailUrl,
+    String name
 ) {
 
     public static AlbumResponse from(final Album album) {

--- a/src/main/java/com/album2me/repost/domain/album/dto/response/AlbumResponse.java
+++ b/src/main/java/com/album2me/repost/domain/album/dto/response/AlbumResponse.java
@@ -2,27 +2,13 @@ package com.album2me.repost.domain.album.dto.response;
 
 import com.album2me.repost.domain.album.model.Album;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-import org.springframework.beans.BeanUtils;
-
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class AlbumResponse {
-
-    private Long id;
-    private Long roomId;
-    private Long writerId;
-    private String thumbnailUrl;
-    private String name;
-    private Long postCount;
+public record AlbumResponse (
+        Long id,
+        String thumbnailUrl,
+        String name
+) {
 
     public static AlbumResponse from(final Album album) {
-        final AlbumResponse albumResponse = new AlbumResponse();
-        BeanUtils.copyProperties(album, albumResponse);
-
-        return albumResponse;
+        return new AlbumResponse(album.getId(), album.getThumbnailUrl(), album.getName());
     }
 }

--- a/src/main/java/com/album2me/repost/domain/album/service/AlbumService.java
+++ b/src/main/java/com/album2me/repost/domain/album/service/AlbumService.java
@@ -6,9 +6,9 @@ import com.album2me.repost.domain.album.dto.response.AlbumResponse;
 import com.album2me.repost.domain.album.model.Album;
 import com.album2me.repost.domain.album.repository.AlbumRepository;
 import com.album2me.repost.domain.room.model.Room;
-import com.album2me.repost.domain.room.repository.RoomRepository;
+import com.album2me.repost.domain.room.service.RoomService;
 import com.album2me.repost.domain.user.model.User;
-import com.album2me.repost.domain.user.repository.UserRepository;
+import com.album2me.repost.domain.user.service.UserService;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,9 +22,9 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class AlbumService {
 
+    private final RoomService roomService;
+    private final UserService userService;
     private final AlbumRepository albumRepository;
-    private final UserRepository userRepository;
-    private final RoomRepository roomRepository;
 
     public List<AlbumResponse> showAll() {
         final List<Album> albums = albumRepository.findAll();
@@ -36,8 +36,8 @@ public class AlbumService {
 
     @Transactional
     public Long create(final Long userId, final AlbumCreateRequest albumCreateRequest) {
-        final User user = findUserById(userId);
-        final Room room = findRoomById(albumCreateRequest.getRoomId());
+        final User user = userService.findUserById(userId);
+        final Room room = roomService.findRoomById(albumCreateRequest.getRoomId());
 
         final Long albumId = createAlbum(user, room, albumCreateRequest);
 
@@ -65,17 +65,7 @@ public class AlbumService {
         albumRepository.delete(album);
     }
 
-    private User findUserById(Long userId) {
-        return userRepository.findById(userId)
-                .orElseThrow(() -> new NoSuchElementException("해당 id로 User를 찾을 수 없습니다."));
-    }
-
-    private Room findRoomById(Long roomId) {
-        return roomRepository.findById(roomId)
-                .orElseThrow(() -> new NoSuchElementException("해당 id로 Room을 찾을 수 없습니다."));
-    }
-
-    private Album findAlbumById(Long albumId) {
+    public Album findAlbumById(Long albumId) {
         return albumRepository.findById(albumId)
                 .orElseThrow(() -> new NoSuchElementException("해당 id로 Album을 찾을 수 없습니다."));
     }

--- a/src/main/java/com/album2me/repost/domain/album/service/AlbumService.java
+++ b/src/main/java/com/album2me/repost/domain/album/service/AlbumService.java
@@ -37,7 +37,7 @@ public class AlbumService {
     @Transactional
     public Long create(final Long userId, final AlbumCreateRequest albumCreateRequest) {
         final User user = userService.findUserById(userId);
-        final Room room = roomService.findRoomById(albumCreateRequest.getRoomId());
+        final Room room = roomService.findRoomById(albumCreateRequest.roomId());
 
         final Long albumId = createAlbum(user, room, albumCreateRequest);
 

--- a/src/main/java/com/album2me/repost/domain/post/controller/PostController.java
+++ b/src/main/java/com/album2me/repost/domain/post/controller/PostController.java
@@ -2,6 +2,7 @@ package com.album2me.repost.domain.post.controller;
 
 import com.album2me.repost.domain.auth.controller.VerifiedUser;
 import com.album2me.repost.domain.post.dto.request.PostCreateRequest;
+import com.album2me.repost.domain.post.dto.request.PostUpdateRequest;
 import com.album2me.repost.domain.post.dto.response.PostResponse;
 import com.album2me.repost.domain.post.service.PostService;
 
@@ -31,15 +32,26 @@ public class PostController {
 
     @PostMapping
     public ResponseEntity<Void> create(
-            @VerifiedUser User user,
-            @Valid @RequestBody PostCreateRequest postCreateRequest
+            @PathVariable final Long albumId,
+            @VerifiedUser final User user,
+            @Valid @RequestBody final PostCreateRequest postCreateRequest
     ) {
-        final Long postId = postService.create(user.getId(), postCreateRequest);
+        final Long postId = postService.create(albumId, user.getId(), postCreateRequest);
 
         return ResponseEntity.created(
                 URI.create("/api/albums/{albumId}/posts" + postId)
         ).build();
     }
 
+    @PutMapping("/{id}")
+    public ResponseEntity<Void> update(
+            @PathVariable final Long id,
+            @VerifiedUser final User user,
+            @Valid @RequestBody final PostUpdateRequest postUpdateRequest
+    ) {
+        postService.update(id, user, postUpdateRequest);
 
+        return ResponseEntity.ok()
+                .build();
+    }
 }

--- a/src/main/java/com/album2me/repost/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/album2me/repost/domain/post/dto/request/PostCreateRequest.java
@@ -5,20 +5,13 @@ import com.album2me.repost.domain.post.model.Post;
 import com.album2me.repost.domain.user.model.User;
 
 import jakarta.validation.constraints.NotNull;
-import lombok.*;
 
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-public class PostCreateRequest {
+public record PostCreateRequest (
+    @NotNull(message = "제목이 없습니다.") String title,
 
-    @NotNull(message = "제목이 없습니다.")
-    private String title;
+    @NotNull(message = "내용이 없습니다.") String contents
+) {
 
-    @NotNull(message = "내용이 없습니다.")
-    private String contents;
-
-    @Builder
     public Post toEntity(final User user, final Album album) {
         return Post.builder()
                 .user(user)

--- a/src/main/java/com/album2me/repost/domain/post/dto/request/PostUpdateRequest.java
+++ b/src/main/java/com/album2me/repost/domain/post/dto/request/PostUpdateRequest.java
@@ -3,19 +3,13 @@ package com.album2me.repost.domain.post.dto.request;
 import com.album2me.repost.domain.post.model.Post;
 
 import jakarta.validation.constraints.NotNull;
-import lombok.*;
 
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-public class PostUpdateRequest {
-    @NotNull(message = "제목이 없습니다.")
-    private String title;
+public record PostUpdateRequest (
+    @NotNull(message = "제목이 없습니다.") String title,
 
-    @NotNull(message = "내용이 없습니다.")
-    private String contents;
+    @NotNull(message = "내용이 없습니다.") String contents
+) {
 
-    @Builder
     public Post toEntity() {
         return Post.builder()
                 .title(title)

--- a/src/main/java/com/album2me/repost/domain/post/dto/request/PostUpdateRequest.java
+++ b/src/main/java/com/album2me/repost/domain/post/dto/request/PostUpdateRequest.java
@@ -1,8 +1,6 @@
 package com.album2me.repost.domain.post.dto.request;
 
-import com.album2me.repost.domain.album.model.Album;
 import com.album2me.repost.domain.post.model.Post;
-import com.album2me.repost.domain.user.model.User;
 
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
@@ -10,8 +8,7 @@ import lombok.*;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class PostCreateRequest {
-
+public class PostUpdateRequest {
     @NotNull(message = "제목이 없습니다.")
     private String title;
 
@@ -19,10 +16,8 @@ public class PostCreateRequest {
     private String contents;
 
     @Builder
-    public Post toEntity(final User user, final Album album) {
+    public Post toEntity() {
         return Post.builder()
-                .user(user)
-                .album(album)
                 .title(title)
                 .contents(contents)
                 .build();

--- a/src/main/java/com/album2me/repost/domain/post/dto/response/PostResponse.java
+++ b/src/main/java/com/album2me/repost/domain/post/dto/response/PostResponse.java
@@ -2,28 +2,13 @@ package com.album2me.repost.domain.post.dto.response;
 
 import com.album2me.repost.domain.post.model.Post;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-import org.springframework.beans.BeanUtils;
-
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class PostResponse {
-
-    private Long id;
-    private Long writerId;
-    private Long albumId;
-    private String title;
-    private String contents;
-    private Long commentCount;
-    private boolean isFavorite;
+public record PostResponse (
+    Long id,
+    String title,
+    String contents
+) {
 
     public static PostResponse from(final Post post) {
-        final PostResponse postResponse = new PostResponse();
-        BeanUtils.copyProperties(post, postResponse);
-
-        return postResponse;
+        return new PostResponse(post.getId(), post.getTitle(), post.getContents());
     }
 }

--- a/src/main/java/com/album2me/repost/domain/post/model/Post.java
+++ b/src/main/java/com/album2me/repost/domain/post/model/Post.java
@@ -7,15 +7,13 @@ import com.album2me.repost.global.common.BaseTimeColumn;
 
 import jakarta.persistence.*;
 
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import org.hibernate.annotations.ColumnDefault;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Entity
 @Getter
@@ -68,6 +66,44 @@ public class Post extends BaseTimeColumn {
         this.commentCount = commentCount;
         this.isFavorite = isFavorite;
    }
+
+    public void update(final Post post) {
+        updateTitle(post.getTitle());
+        updateContents(post.getContents());
+    }
+
+    private void updateTitle(final String title) {
+        if (title != null) {
+            this.title = title;
+        }
+    }
+
+    private void updateContents(final String contents) {
+        if (contents != null) {
+            this.contents = contents;
+        }
+    }
+
+    public boolean isWrittenBy(final User user) {
+        return this.user.equals(user);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Post)) {
+            return false;
+        }
+        final Post post = (Post) o;
+        return Objects.equals(id, post.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
 }
 
 

--- a/src/main/java/com/album2me/repost/domain/room/service/RoomService.java
+++ b/src/main/java/com/album2me/repost/domain/room/service/RoomService.java
@@ -1,0 +1,21 @@
+package com.album2me.repost.domain.room.service;
+
+import com.album2me.repost.domain.room.model.Room;
+import com.album2me.repost.domain.room.repository.RoomRepository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.NoSuchElementException;
+
+@Service
+@RequiredArgsConstructor
+public class RoomService {
+
+    private final RoomRepository roomRepository;
+
+    public Room findRoomById(Long roomId) {
+        return roomRepository.findById(roomId)
+                .orElseThrow(() -> new NoSuchElementException("해당 id로 Room을 찾을 수 없습니다."));
+    }
+}

--- a/src/main/java/com/album2me/repost/domain/user/service/UserService.java
+++ b/src/main/java/com/album2me/repost/domain/user/service/UserService.java
@@ -6,6 +6,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.NoSuchElementException;
+
 @Service
 @RequiredArgsConstructor
 public class UserService {
@@ -13,9 +15,15 @@ public class UserService {
     public void signUp(User user){
         userRepository.save(user);
     }
-    public User findUserByAuthId(String authId){
-        User user = userRepository.findByAuthId(authId)
-                .orElseThrow(() -> new IllegalArgumentException(""));
-        return user;
+
+    public User findUserByAuthId(final String authId){
+        return userRepository.findByAuthId(authId)
+                .orElseThrow(() -> new NoSuchElementException(""));
+
+    }
+
+    public User findUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new NoSuchElementException("해당 id로 User를 찾을 수 없습니다."));
     }
 }

--- a/src/main/java/com/album2me/repost/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/album2me/repost/global/error/GlobalExceptionHandler.java
@@ -1,10 +1,13 @@
 package com.album2me.repost.global.error;
 
 import com.album2me.repost.global.error.ErrorResponse.FieldException;
+
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
+
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -16,9 +19,9 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ExceptionHandler({MethodArgumentNotValidException.class, IllegalArgumentException.class})
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public ErrorResponse handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+    public ErrorResponse handleMethodArgumentNotValidException(final MethodArgumentNotValidException e) {
         log.debug("Bad request exception occurred: {}", e.getMessage(), e);
         List<FieldException> details = createFieldExceptionList(e.getBindingResult());
         return ErrorResponse.badRequest(ErrorCode.INVALID_ARGUMENT, details);
@@ -26,7 +29,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(NoSuchElementException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
-    public ErrorResponse handleNoSuchElementException(NoSuchElementException e) {
+    public ErrorResponse handleNoSuchElementException(final NoSuchElementException e) {
         log.debug("Not Found exception occurred: {}", e.getMessage(), e);
         return ErrorResponse.notFound(ErrorCode.NOT_FOUND);
     }


### PR DESCRIPTION
close #15 

## 작업 내용
- 포스트 수정 기능 구현
- DTO record 적용

## 고민한 내용
🤔 service 레이어에서 다른 service를 의존하는 것이 좋을지, repository를 의존하는 것이 좋을지 고민했습니다.

➡️ 결과적으로, service에서 다른 service를 의존하는 구조를 채택했습니다. 주로 한 서비스에서 다른 엔티티 객체가 필요한 경우에 repository에서 찾아 가져오도록 하였습니다.

 한 service에서 여러 개의 도메인이 생겨나면 여러 repository를 의존하게 되고, 무엇보다 해당 repository에서 조회의 책임은 같은 도메인의 service에서 이루어지는 것이 적합하다고 판단하여 service에서 다른 service를 의존하는 구조를 채택했습니다. 
하지만, 이는 자칫 순환 참조 문제를 발생시키기 쉬우므로 추후에 조회 로직만 따로 분리한 서비스를 별도로 두는 방법도 고민 중에 있습니다.

https://github.com/woowacourse/retrospective/discussions/15
해당 discussion을 참고했습니다.

## 참고 사항
-
