### PR TITLE
방 생성 기능 구현 (#62)

### DIFF
--- a/src/main/java/com/album2me/repost/domain/member/Member.java
+++ b/src/main/java/com/album2me/repost/domain/member/Member.java
@@ -8,19 +8,33 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseTimeColumn {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id")
     private Room room;
+
+    private boolean isHost;
+
+    public Member(User user, Room room, boolean isHost) {
+        this.user = user;
+        this.room = room;
+        this.isHost = isHost;
+    }
 }

--- a/src/main/java/com/album2me/repost/domain/member/Member.java
+++ b/src/main/java/com/album2me/repost/domain/member/Member.java
@@ -1,0 +1,26 @@
+package com.album2me.repost.domain.member;
+
+import com.album2me.repost.domain.room.model.Room;
+import com.album2me.repost.domain.user.model.User;
+import com.album2me.repost.global.common.BaseTimeColumn;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class Member extends BaseTimeColumn {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Room room;
+}

--- a/src/main/java/com/album2me/repost/domain/room/controller/RoomController.java
+++ b/src/main/java/com/album2me/repost/domain/room/controller/RoomController.java
@@ -1,0 +1,29 @@
+package com.album2me.repost.domain.room.controller;
+
+import com.album2me.repost.domain.room.dto.RoomCreateRequest;
+import com.album2me.repost.domain.room.dto.RoomCreateResponse;
+import com.album2me.repost.domain.room.service.RoomService;
+import com.album2me.repost.global.config.security.jwt.JwtAuthentication;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/room")
+public class RoomController {
+    private final RoomService roomService;
+
+    @PostMapping
+    public ResponseEntity<RoomCreateResponse> createRoom(@RequestBody @Valid RoomCreateRequest roomCreateRequest,
+                                                         @AuthenticationPrincipal JwtAuthentication jwtAuthentication) {
+        return ResponseEntity.ok(
+                roomService.createRoom(roomCreateRequest, jwtAuthentication.getId())
+        );
+    }
+}

--- a/src/main/java/com/album2me/repost/domain/room/dto/RoomCreateRequest.java
+++ b/src/main/java/com/album2me/repost/domain/room/dto/RoomCreateRequest.java
@@ -1,0 +1,6 @@
+package com.album2me.repost.domain.room.dto;
+
+public record RoomCreateRequest(
+        String name
+) {
+}

--- a/src/main/java/com/album2me/repost/domain/room/dto/RoomCreateResponse.java
+++ b/src/main/java/com/album2me/repost/domain/room/dto/RoomCreateResponse.java
@@ -1,0 +1,6 @@
+package com.album2me.repost.domain.room.dto;
+
+public record RoomCreateResponse(
+        Long roomId
+) {
+}

--- a/src/main/java/com/album2me/repost/domain/room/model/Room.java
+++ b/src/main/java/com/album2me/repost/domain/room/model/Room.java
@@ -2,11 +2,15 @@ package com.album2me.repost.domain.room.model;
 
 import com.album2me.repost.domain.member.Member;
 import com.album2me.repost.global.common.BaseTimeColumn;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -22,6 +26,18 @@ public class Room extends BaseTimeColumn {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToMany(mappedBy = "room")
+    @Column(length = 20, nullable = false)
+    private String name;
+
+    @OneToMany(mappedBy = "room", cascade = CascadeType.ALL)
     private List<Member> members = new ArrayList<>();
+
+
+    public Room(String name) {
+        this.name = name;
+    }
+
+    public void addMember(Member member) {
+        members.add(member);
+    }
 }

--- a/src/main/java/com/album2me/repost/domain/room/model/Room.java
+++ b/src/main/java/com/album2me/repost/domain/room/model/Room.java
@@ -1,10 +1,14 @@
 package com.album2me.repost.domain.room.model;
 
+import com.album2me.repost.domain.member.Member;
 import com.album2me.repost.global.common.BaseTimeColumn;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,4 +22,6 @@ public class Room extends BaseTimeColumn {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @OneToMany(mappedBy = "room")
+    private List<Member> members = new ArrayList<>();
 }

--- a/src/main/java/com/album2me/repost/domain/room/service/RoomService.java
+++ b/src/main/java/com/album2me/repost/domain/room/service/RoomService.java
@@ -1,8 +1,14 @@
 package com.album2me.repost.domain.room.service;
 
+import com.album2me.repost.domain.member.Member;
+import com.album2me.repost.domain.room.dto.RoomCreateRequest;
+import com.album2me.repost.domain.room.dto.RoomCreateResponse;
 import com.album2me.repost.domain.room.model.Room;
 import com.album2me.repost.domain.room.repository.RoomRepository;
 
+import com.album2me.repost.domain.user.model.User;
+import com.album2me.repost.domain.user.service.UserService;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -11,11 +17,22 @@ import java.util.NoSuchElementException;
 @Service
 @RequiredArgsConstructor
 public class RoomService {
+    private final UserService userService;
 
     private final RoomRepository roomRepository;
 
     public Room findRoomById(Long roomId) {
         return roomRepository.findById(roomId)
                 .orElseThrow(() -> new NoSuchElementException("해당 id로 Room을 찾을 수 없습니다."));
+    }
+
+    @Transactional
+    public RoomCreateResponse createRoom(RoomCreateRequest roomCreateRequest, Long userId) {
+        User user = userService.findUserById(userId);
+        Room newRoom = new Room(roomCreateRequest.name());
+        Member host = new Member(user, newRoom, true);
+        newRoom.addMember(host);
+        roomRepository.save(newRoom);
+        return new RoomCreateResponse(newRoom.getId());
     }
 }

--- a/src/main/java/com/album2me/repost/domain/user/model/User.java
+++ b/src/main/java/com/album2me/repost/domain/user/model/User.java
@@ -1,7 +1,10 @@
 package com.album2me.repost.domain.user.model;
 
+import com.album2me.repost.domain.member.Member;
 import com.album2me.repost.global.common.BaseTimeColumn;
 import jakarta.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,6 +26,9 @@ public class User extends BaseTimeColumn {
 
     @Column(length = 20, unique = true, nullable = false)
     private String nickName;
+
+    @OneToMany(mappedBy = "user")
+    List<Member> members = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)
     private Role role = Role.ROLE_USER;

--- a/src/main/java/com/album2me/repost/global/config/security/jwt/JwtAuthentication.java
+++ b/src/main/java/com/album2me/repost/global/config/security/jwt/JwtAuthentication.java
@@ -1,7 +1,9 @@
 package com.album2me.repost.global.config.security.jwt;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+@Getter
 @RequiredArgsConstructor
 public class JwtAuthentication {
     private final Long id;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
     password: ENC(NafMrdQSRzbJN+YK3qWHWQ==)
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         show_sql: true


### PR DESCRIPTION
Close #62 

## 작업 내용
- 방 생성 기능 구현

## 참고 내용
- 기존에 Security를 할때 UserDetails 객체를 사용하지 않고 따로 JwtAuthentication이라는 객체를 정의해 사용했습니다. JwtAuthentication이라고 이름을 지은 것은 Jwt를 통한 Authentication 객체라는 것을 명확히 하기 위해서였는데요, 
그러다 보니 현재 로그인된 유저를 보여주기 위해 @AuthenticationPrincipal JwtAuthentication jwtAuthentication을 사용해야하고, 기존에 작성하신 @VerifiedUser User user의 코드와 충돌이 나버리게 됩니다.
이부분에서 조정이 필요해 보여요.
